### PR TITLE
refactor: remove duplicidade da classe str

### DIFF
--- a/BlocoX.Test/BlocoX.Test.csproj
+++ b/BlocoX.Test/BlocoX.Test.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BlocoX.Utils\BlocoX.Utils.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/BlocoX.Test/BlocoX.Test.csproj
+++ b/BlocoX.Test/BlocoX.Test.csproj
@@ -1,19 +1,74 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-
-    <IsPackable>false</IsPackable>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1BA1526B-96FC-4789-BDD7-292A5C69D466}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BlocoX.Test</RootNamespace>
+    <AssemblyName>BlocoX.Test</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
-
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="..\BlocoX.Utils\BlocoX.Utils.csproj" />
+    <Compile Include="BlocoX.Utils\strTest.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BlocoX.Utils\BlocoX.Utils.csproj">
+      <Project>{a4e1f0f4-ba8d-4adf-8163-44128a5c974b}</Project>
+      <Name>BlocoX.Utils</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
 </Project>

--- a/BlocoX.Test/BlocoX.Utils/strTest.cs
+++ b/BlocoX.Test/BlocoX.Utils/strTest.cs
@@ -1,0 +1,55 @@
+﻿using BlocoX.Utils;
+using BlocoX.Utils.Enums;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BlocoX.Test.BlocoX.Utils
+{
+    [TestClass]
+    [TestCategory("STR - Classe corta e completa")]
+    public class strTest
+    {
+        [TestMethod]
+        public void Deve_validar_alinhamento_a_esquerda()
+        {
+            var texto = 10;
+            Assert.AreEqual("0010", texto.ToString().CortaCompleta(4, "0", Alinhamento.Esquerda));
+        }
+
+        [TestMethod]
+        public void Deve_validar_alinhamento_a_direita()
+        {
+            var texto = 10;
+            Assert.AreEqual("1000", texto.ToString().CortaCompleta(4, "0", Alinhamento.Direita));
+        }
+
+
+        [TestMethod]
+        public void Deve_validar_PreencherComEspacoEmBranco_alinhado_a_esquerda()
+        {
+            var texto = 10;
+            Assert.AreEqual("  10", texto.ToString().CortaCompleta(4, null, Alinhamento.Esquerda));
+        }
+
+        [TestMethod]
+        public void Deve_validar_PreencherComEspacoEmBranco_alinhado_a_direita()
+        {
+            var texto = 10;
+            Assert.AreEqual("10  ", texto.ToString().CortaCompleta(4, null, Alinhamento.Direita));
+        }
+
+        [TestMethod]
+        public void Deve_validar_Venda_bruta_diaria()
+        {
+            var numero = 10.00m;
+            Assert.AreEqual("00000000001000", numero.ToString("n2").Replace(",","").Replace(".","").CortaCompleta(14, "0", Alinhamento.Esquerda));
+        }
+
+
+        [TestMethod]
+        public void Deve_validar_GT()
+        {
+            var numero = 10.00m;
+            Assert.AreEqual("000000000000001000", numero.ToString("n2").Replace(",", "").Replace(".", "").CortaCompleta(18, "0", Alinhamento.Esquerda));
+        }
+    }
+}

--- a/BlocoX.Test/BlocoX.Utils/strTest.cs
+++ b/BlocoX.Test/BlocoX.Utils/strTest.cs
@@ -41,7 +41,7 @@ namespace BlocoX.Test.BlocoX.Utils
         public void Deve_validar_Venda_bruta_diaria()
         {
             var numero = 10.00m;
-            Assert.AreEqual("00000000001000", numero.ToString("n2").Replace(",","").Replace(".","").CortaCompleta(14, "0", Alinhamento.Esquerda));
+            Assert.AreEqual("00000000001000", numero.ToString("n2").Replace(",", "").Replace(".", "").CortaCompleta(14, "0", Alinhamento.Esquerda));
         }
 
 

--- a/BlocoX.Test/Properties/AssemblyInfo.cs
+++ b/BlocoX.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("BlocoX.Test")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("BlocoX.Test")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("1ba1526b-96fc-4789-bdd7-292a5c69d466")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/BlocoX.Test/packages.config
+++ b/BlocoX.Test/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net45" />
+  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net45" />
+</packages>

--- a/BlocoX.Utils/BlocoX.Utils.csproj
+++ b/BlocoX.Utils/BlocoX.Utils.csproj
@@ -46,7 +46,7 @@
     <Compile Include="Arquivos\Exemplo.cs" />
     <Compile Include="Config.cs" />
     <Compile Include="DynamicJsonConverter.cs" />
-    <Compile Include="Enums.cs" />
+    <Compile Include="Enums\Alinhamento.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="str.cs" />
     <Compile Include="XML.cs" />

--- a/BlocoX.Utils/Enums/Alinhamento.cs
+++ b/BlocoX.Utils/Enums/Alinhamento.cs
@@ -1,0 +1,42 @@
+﻿/********************************************************************************/
+/* Projeto: Biblioteca BlocoX                                                   */
+/* Biblioteca C# para emissão do BlocoX (ReduçãoZ e Estoque)                    */
+/*https://www.confaz.fazenda.gov.br/legislacao/despacho/2017/dp045_17           */
+/*                                                                              */
+/* Direitos Autorais Reservados (c) 2019 Alexsandro Bertoncini                  */
+/*                                       alex.bertoncini@terra.com.br           */
+/*                                                                              */
+/*  Você pode obter a última versão desse arquivo no GitHub                     */
+/* localizado em https://github.com/Bertoncini/BlocoX                           */
+/*                                                                              */
+/*                                                                              */
+/*  Esta biblioteca é software livre; você pode redistribuí-la e/ou modificá-la */
+/* sob os termos da Licença Pública Geral Menor do GNU conforme publicada pela  */
+/* Free Software Foundation; tanto a versão 2.1 da Licença, ou (a seu critério) */
+/* qualquer versão posterior.                                                   */
+/*                                                                              */
+/*  Esta biblioteca é distribuída na expectativa de que seja útil, porém, SEM   */
+/* NENHUMA GARANTIA; nem mesmo a garantia implícita de COMERCIABILIDADE OU      */
+/* ADEQUAÇÃO A UMA FINALIDADE ESPECÍFICA. Consulte a Licença Pública Geral Menor*/
+/* do GNU para mais detalhes. (Arquivo LICENÇA.TXT ou LICENSE.TXT)              */
+/*                                                                              */
+/*  Você deve ter recebido uma cópia da Licença Pública Geral Menor do GNU junto*/
+/* com esta biblioteca; se não, escreva para a Free Software Foundation, Inc.,  */
+/* no endereço 59 Temple Street, Suite 330, Boston, MA 02111-1307 USA.          */
+/* Você também pode obter uma copia da licença em:                              */
+/* http://www.opensource.org/licenses/lgpl-license.php                          */
+/*                                                                              */
+/********************************************************************************/
+namespace BlocoX.Utils.Enums
+{
+    using System.ComponentModel;
+
+    public enum Alinhamento
+    {
+        [Description("Esquerda")]
+        Esquerda = 0,
+
+        [Description("Direita")]
+        Direita = 1
+    }
+}

--- a/BlocoX.Utils/XML.cs
+++ b/BlocoX.Utils/XML.cs
@@ -29,6 +29,7 @@
 /********************************************************************************/
 namespace BlocoX.Utils
 {
+    using BlocoX.Utils.Enums;
     using System.Collections.Generic;
     using System.Xml;
 
@@ -53,11 +54,11 @@ namespace BlocoX.Utils
             <DadosReducaoZ>
                 <DataReferencia>{jsonObject.Ecf.DadosReducaoZ.DataReferencia.ToString("yyyy-MM-dd")}</DataReferencia>
                 <DataHoraEmissao>{jsonObject.Ecf.DadosReducaoZ.DataHoraEmissao.ToString("yyyy-MM-ddTHH:mm:ss-03:00")}</DataHoraEmissao>
-                <CRZ>{jsonObject.Ecf.DadosReducaoZ.CRZ.ToString().CortaCompleta(4, "0", eOrietacao.Esquerda)}</CRZ>
-                <COO>{jsonObject.Ecf.DadosReducaoZ.COO.ToString().CortaCompleta(9, "0", eOrietacao.Esquerda)}</COO>
-                <CRO>{jsonObject.Ecf.DadosReducaoZ.CRO.ToString().CortaCompleta(3, "0", eOrietacao.Esquerda)}</CRO>
-                <VendaBrutaDiaria>{jsonObject.Ecf.DadosReducaoZ.VendaBrutaDiaria.ToString("N2").Replace(",", "").Replace(".", "").CortaCompleta(14, "0", eOrietacao.Esquerda)}</VendaBrutaDiaria>
-                <GT>{jsonObject.Ecf.DadosReducaoZ.GT.ToString("N2").Replace(",", "").Replace(".", "").CortaCompleta(18, "0", eOrietacao.Esquerda)}</GT>
+                <CRZ>{jsonObject.Ecf.DadosReducaoZ.CRZ.ToString().CortaCompleta(4, "0", Alinhamento.Esquerda)}</CRZ>
+                <COO>{jsonObject.Ecf.DadosReducaoZ.COO.ToString().CortaCompleta(9, "0", Alinhamento.Esquerda)}</COO>
+                <CRO>{jsonObject.Ecf.DadosReducaoZ.CRO.ToString().CortaCompleta(3, "0", Alinhamento.Esquerda)}</CRO>
+                <VendaBrutaDiaria>{jsonObject.Ecf.DadosReducaoZ.VendaBrutaDiaria.ToString("N2").Replace(",", "").Replace(".", "").CortaCompleta(14, "0", Alinhamento.Esquerda)}</VendaBrutaDiaria>
+                <GT>{jsonObject.Ecf.DadosReducaoZ.GT.ToString("N2").Replace(",", "").Replace(".", "").CortaCompleta(18, "0", Alinhamento.Esquerda)}</GT>
                 <TotalizadoresParciais>
                     {xmlStringBlocoXRzTotalizadorParcial(jsonObject.Ecf.DadosReducaoZ.TotalizadoresParciais)}
                 </TotalizadoresParciais>
@@ -117,11 +118,11 @@ namespace BlocoX.Utils
             <DadosReducaoZ>
                 <DataReferencia>{blocoXRz.Ecf.DadosReducaoZ.DataReferencia.ToString("yyyy-MM-dd")}</DataReferencia>
                 <DataHoraEmissao>{blocoXRz.Ecf.DadosReducaoZ.DataHoraEmissao.ToString("yyyy-MM-ddTHH:mm:ss-03:00")}</DataHoraEmissao>
-                <CRZ>{blocoXRz.Ecf.DadosReducaoZ.CRZ.ToString().CortaCompleta(4, "0", eOrietacao.Esquerda)}</CRZ>
-                <COO>{blocoXRz.Ecf.DadosReducaoZ.COO.ToString().CortaCompleta(9, "0", eOrietacao.Esquerda)}</COO>
-                <CRO>{blocoXRz.Ecf.DadosReducaoZ.CRO.ToString().CortaCompleta(3, "0", eOrietacao.Esquerda)}</CRO>
-                <VendaBrutaDiaria>{blocoXRz.Ecf.DadosReducaoZ.VendaBrutaDiaria.ToString("N2").Replace(",", "").Replace(".", "").CortaCompleta(14, "0", eOrietacao.Esquerda)}</VendaBrutaDiaria>
-                <GT>{blocoXRz.Ecf.DadosReducaoZ.GT.ToString("N2").Replace(",", "").Replace(".", "").CortaCompleta(18, "0", eOrietacao.Esquerda)}</GT>
+                <CRZ>{blocoXRz.Ecf.DadosReducaoZ.CRZ.ToString().CortaCompleta(4, "0", Alinhamento.Esquerda)}</CRZ>
+                <COO>{blocoXRz.Ecf.DadosReducaoZ.COO.ToString().CortaCompleta(9, "0", Alinhamento.Esquerda)}</COO>
+                <CRO>{blocoXRz.Ecf.DadosReducaoZ.CRO.ToString().CortaCompleta(3, "0", Alinhamento.Esquerda)}</CRO>
+                <VendaBrutaDiaria>{blocoXRz.Ecf.DadosReducaoZ.VendaBrutaDiaria.ToString("N2").Replace(",", "").Replace(".", "").CortaCompleta(14, "0", Alinhamento.Esquerda)}</VendaBrutaDiaria>
+                <GT>{blocoXRz.Ecf.DadosReducaoZ.GT.ToString("N2").Replace(",", "").Replace(".", "").CortaCompleta(18, "0", Alinhamento.Esquerda)}</GT>
                 <TotalizadoresParciais>
                     {xmlStringBlocoXRzTotalizadorParcial(blocoXRz.Ecf.DadosReducaoZ.TotalizadoresParciais)}
                 </TotalizadoresParciais>

--- a/BlocoX.Utils/str.cs
+++ b/BlocoX.Utils/str.cs
@@ -27,6 +27,8 @@
 /* http://www.opensource.org/licenses/lgpl-license.php                          */
 /*                                                                              */
 /********************************************************************************/
+using BlocoX.Utils.Enums;
+
 namespace BlocoX.Utils
 {
     public static class Str
@@ -35,26 +37,29 @@ namespace BlocoX.Utils
         /// Corta e completa a string de acordo com o tamanho e orientação passadas
         /// </summary>
         /// <param name="str">String a ser modificada</param>
-        /// <param name="tamanho">Tamanho final da string</param>
-        /// <param name="strCompletar">String a completa os espaços</param>
-        /// <param name="orientacao">Completa a esquerda ou direita</param>
+        /// <param name="quantidadeDeCasas">Tamanho final da string</param>
+        /// <param name="valorParaPreencher">String a completa os espaços</param>
+        /// <param name="alinhamento">Completa a esquerda ou direita</param>
         /// <returns>Nova string modificada</returns>
-        public static string CortaCompleta(this string str, int tamanho = 1, string strCompletar = null, eOrietacao orientacao = eOrietacao.Direita)
+        public static string CortaCompleta(this string str, int quantidadeDeCasas = 1, string valorParaPreencher = null, Alinhamento alinhamento = Alinhamento.Direita)
         {
-            str = str ?? string.Empty;
+            if (PreencherComEspacoEmBranco(valorParaPreencher))
+                return ObterTextoAlinhadoComEspacoEmBranco(alinhamento, str, quantidadeDeCasas);
 
-            if(string.IsNullOrWhiteSpace(strCompletar))
-                if(orientacao == eOrietacao.Esquerda)
-                    return str.PadLeft(tamanho);
-                else
-                    return str.PadRight(tamanho);
-            else
-            {
-                if(orientacao == eOrietacao.Esquerda)
-                    return str.PadLeft(tamanho).Substring(0, str.PadLeft(tamanho).Length - str.Length).Replace(" ", strCompletar) + str;
-                else
-                    return str + str.PadRight(tamanho).Substring(str.Length, str.PadRight(tamanho).Length - str.Length).Replace(" ", strCompletar);
-            }
+            return ObterTextoAlinhadoComEspacoEmBranco(alinhamento, str, quantidadeDeCasas).Replace(" ", valorParaPreencher);
+
         }
+
+        private static bool PreencherComEspacoEmBranco(string stringComplementar)
+            => string.IsNullOrWhiteSpace(stringComplementar);
+
+        private static string ObterTextoAlinhadoComEspacoEmBranco(Alinhamento alinhamento, string texto, int quantidadeDeCasas)
+        {
+            if (alinhamento == Alinhamento.Esquerda)
+                return texto.PadLeft(quantidadeDeCasas);
+
+            return texto.PadRight(quantidadeDeCasas);
+        }
+
     }
 }

--- a/BlocoX.sln
+++ b/BlocoX.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlocoX.Utils", "BlocoX.Util
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlocoX.Modelos", "BlocoX.Modelos\BlocoX.Modelos.csproj", "{875437FF-B761-4105-B2AC-59A6848B917D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlocoX.Test", "BlocoX.Test\BlocoX.Test.csproj", "{369AC273-DE12-40C6-B54F-FF516FF34714}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{875437FF-B761-4105-B2AC-59A6848B917D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{875437FF-B761-4105-B2AC-59A6848B917D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{875437FF-B761-4105-B2AC-59A6848B917D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{369AC273-DE12-40C6-B54F-FF516FF34714}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{369AC273-DE12-40C6-B54F-FF516FF34714}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{369AC273-DE12-40C6-B54F-FF516FF34714}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{369AC273-DE12-40C6-B54F-FF516FF34714}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/BlocoX.sln
+++ b/BlocoX.sln
@@ -11,7 +11,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlocoX.Utils", "BlocoX.Util
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlocoX.Modelos", "BlocoX.Modelos\BlocoX.Modelos.csproj", "{875437FF-B761-4105-B2AC-59A6848B917D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlocoX.Test", "BlocoX.Test\BlocoX.Test.csproj", "{369AC273-DE12-40C6-B54F-FF516FF34714}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlocoX.Test", "BlocoX.Test\BlocoX.Test.csproj", "{1BA1526B-96FC-4789-BDD7-292A5C69D466}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -35,10 +35,10 @@ Global
 		{875437FF-B761-4105-B2AC-59A6848B917D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{875437FF-B761-4105-B2AC-59A6848B917D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{875437FF-B761-4105-B2AC-59A6848B917D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{369AC273-DE12-40C6-B54F-FF516FF34714}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{369AC273-DE12-40C6-B54F-FF516FF34714}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{369AC273-DE12-40C6-B54F-FF516FF34714}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{369AC273-DE12-40C6-B54F-FF516FF34714}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1BA1526B-96FC-4789-BDD7-292A5C69D466}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1BA1526B-96FC-4789-BDD7-292A5C69D466}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1BA1526B-96FC-4789-BDD7-292A5C69D466}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1BA1526B-96FC-4789-BDD7-292A5C69D466}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### Problema
A função CortaCompleta possuía processamento em duplicidade, em alguns trechos.

### Solução

1. Removida duplicidade da classe Str
2. Movido Enum para pasta Enums 
3. Alterado o nome de eOrientacao para Alinhamento, (removida dotação húngara) 
